### PR TITLE
Fix typos and improve readability in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,26 @@ A simple block-chain framework written in C#
 
 ## Goals
 
-This project should create a framework to do these:
+This project creates a framework to do the following:
 
-1. Create and manage a block-chain storage for storing of blocks linked to the previous block via a custom hash function
-2. Give helper methods to store and retrieve data from block-chain
-3. Handle security and signing in message passing and addind items to chain
+1. Create and manage a block-chain storage for storing blocks linked to the previous block via a custom hash function.
+2. Provide helper methods to store and retrieve data from block-chain.
+3. Handle security and signing in messages passing and adding items to the chain, including:
 	1. Give helper methods to create required signing keys
-	2. Verify blocks as they are being created using the signing keys
-4. Have multiple persisting strategies for easier use
+	2. Verify blocks as they are created using the signing keys
+4. Have multiple persisting strategies for easier use.
 
 ## How to Use
 
-How to use is simple. There is a `ChainFactory` that creates an object of type `Chain`. All you need is here in the chain object.
+It is simple to use. There is a `ChainFactory` that creates an object of type `Chain`, which is all needed.
 
 ```C#
 var chain = ChainFactory.Create<string>();
 ```
 
-#### Creating a Block
+#### Create a Block
 
-If you are creatign your own block first get its hash with `CreateBlock` and the add it to chain with `AddBlock`
+If creating your own block, first get its hash with `CreateBlock`, and then add it to chain with `AddBlock`
 
 ```C#
 var message = "I'm a new block";
@@ -35,11 +35,11 @@ chain.AddBlock(message, hash);
 
 #### Send the Block
 
-You then send the previously created block along with its hash.
+Send the created block along with its hash.
 
-#### Receiving and Validating a Block
+#### Receive and Validate a Block
 
-If you have received a block it has a content and a hash. You then just call the `AddBlock` method of the chain to insert it in your local block-chain. Listen for the Boolean result of this method which checks the incoming block and returns true only if this block matches the chain so far and then adds it to the chain.
+If you have received a block and it has a content and a hash, call the `AddBlock` method of the chain to insert it in your local block-chain. Listen for the Boolean result of this method, which checks the incoming block, returns true and  adds it to the chain only if this block matches the chain so far.
 
 ```C#
 if(chain.AddBlock(message, hash))
@@ -54,4 +54,4 @@ else
 
 ## Example
 
-An example is also available which is just a proof of concept type of project. **ChainSaw** is a sample chat application that allows two client to chat using a server. The server in this case is different with other chat application servers in that it's a dummy message passing proxy and the data is kept and verified in client side using block-chains.
+An example is also available which is just a proof of concept type of project. **ChainSaw** is a sample chat application that allows two clients to chat using a server. The server in this case is different with other chat application servers in that it's a dummy message passing proxy and the data is kept and verified in client side using block-chains.


### PR DESCRIPTION
- should create -> creates
- these -> the following (following the principle of Avoiding pronoun in technical writing :) )
- How to use is simple -> It is simple to use
- Give -> Helper
- Creating/Receiving/Validating -> Create/Receive/Validate (Be consistent in subheadings)
- If you are creatign -> If creating
- two client -> two clients
- Also fixed some sentence structures and subordinate clauses ...